### PR TITLE
chore: cleanup and improve the index

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,2 @@
 [registries]
-nkcompute = { index = "sparse+https://crates-registry.nkcompute.net/" }
+nkcompute = { index = "sparse+https://crates-registry.nkcompute.net/index/" }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -702,7 +702,7 @@ dependencies = [
 
 [[package]]
 name = "freighter"
-version = "0.0.9"
+version = "0.0.10-rc.5"
 dependencies = [
  "anyhow",
  "axum",
@@ -737,13 +737,14 @@ dependencies = [
 
 [[package]]
 name = "freighter-index"
-version = "0.0.7"
+version = "0.0.8-rc.5"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "deadpool-postgres",
  "futures-util",
+ "metrics",
  "postgres-types",
  "semver",
  "serde",
@@ -754,7 +755,7 @@ dependencies = [
 
 [[package]]
 name = "freighter-server"
-version = "0.0.9"
+version = "0.0.10-rc.5"
 dependencies = [
  "anyhow",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,8 @@ members = [
 
 [workspace.dependencies]
 freighter-auth = { path = "freighter-auth", registry = "nkcompute", version = "0.0.7" }
-freighter-index = { path = "freighter-index", registry = "nkcompute", version = "0.0.7" }
-freighter-server = { path = "freighter-server", registry = "nkcompute", version = "0.0.9" }
+freighter-index = { path = "freighter-index", registry = "nkcompute", version = "0.0.8" }
+freighter-server = { path = "freighter-server", registry = "nkcompute", version = "0.0.10" }
 freighter-storage = { path = "freighter-storage", registry = "nkcompute", version = "0.0.7" }
 
 anyhow = "1.0.71"

--- a/freighter-index/Cargo.toml
+++ b/freighter-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freighter-index"
-version = "0.0.7"
+version = "0.0.8"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Noah Kennedy <nomaxx117@gmail.com>"]
@@ -19,6 +19,7 @@ async-trait = { workspace = true }
 axum = { workspace = true }
 deadpool-postgres = { workspace = true }
 futures-util = { workspace = true }
+metrics = { workspace = true }
 postgres-types = { workspace = true, features = ["derive"], optional = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }

--- a/freighter-index/sql/confirm-existence.sql
+++ b/freighter-index/sql/confirm-existence.sql
@@ -1,0 +1,5 @@
+select cv.yanked
+from crates
+         join crate_versions cv on crates.id = cv.crate
+where crates.name = $1
+  and cv.version = $2

--- a/freighter-index/sql/list.sql
+++ b/freighter-index/sql/list.sql
@@ -15,6 +15,5 @@ from crates
          left join crate_keywords ck on crates.id = ck.crate
          join keywords k on k.id = ck.keyword
 where crates.registry is null
-  and position($1 in crates.name) > 0
 group by crates.name, crates.description, crates.documentation, crates.homepage, crates.repository
 having count(cv.version) > 0

--- a/freighter-index/src/api_types.rs
+++ b/freighter-index/src/api_types.rs
@@ -131,6 +131,15 @@ pub struct SearchQuery {
     pub per_page: Option<usize>,
 }
 
+/// Pagination information for certain operations.
+#[derive(Clone, Deserialize)]
+pub struct ListQuery {
+    /// The number of crates to show in a given page.
+    pub per_page: Option<usize>,
+    /// The page to show.
+    pub page: Option<usize>,
+}
+
 #[derive(Serialize)]
 pub struct SearchResults {
     /// Array of results.
@@ -152,6 +161,11 @@ pub struct SearchResultsEntry {
     pub max_version: Version,
     /// Textual description of the crate.
     pub description: String,
+    pub homepage: Option<String>,
+    pub repository: Option<String>,
+    pub documentation: Option<String>,
+    pub keywords: Vec<String>,
+    pub categories: Vec<String>,
 }
 
 #[derive(Deserialize)]

--- a/freighter-index/src/lib.rs
+++ b/freighter-index/src/lib.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 use semver::Version;
-use serde::{Deserialize, Serialize};
+
 use std::future::Future;
 use std::pin::Pin;
 
@@ -35,6 +35,8 @@ pub trait IndexClient: Sync {
     /// If an error occurs while trying to generate the sparse entry, [`IndexError::ServiceError`]
     /// will be returned.
     async fn get_sparse_entry(&self, crate_name: &str) -> IndexResult<Vec<CrateVersion>>;
+    /// Confirm that a particular crate and version pair exists, and return its yank status
+    async fn confirm_existence(&self, crate_name: &str, version: &Version) -> IndexResult<bool>;
     /// Yank a crate version.
     async fn yank_crate(&self, crate_name: &str, version: &Version) -> IndexResult<()>;
     /// Unyank a crate version
@@ -57,14 +59,5 @@ pub trait IndexClient: Sync {
     /// List crates in the index, optionally specifying pagination.
     ///
     /// If no pagination is provided, all crates should be returned.
-    async fn list(&self, pagination: Option<&Pagination>) -> IndexResult<Vec<SearchResultsEntry>>;
-}
-
-/// Pagination information for certain operations.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct Pagination {
-    /// The number of crates to show in a given page.
-    per_page: usize,
-    /// The page to show.
-    page: usize,
+    async fn list(&self, pagination: &ListQuery) -> IndexResult<Vec<SearchResultsEntry>>;
 }

--- a/freighter-server/Cargo.toml
+++ b/freighter-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freighter-server"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Noah Kennedy <nomaxx117@gmail.com>"]

--- a/freighter-server/src/downloads.rs
+++ b/freighter-server/src/downloads.rs
@@ -4,13 +4,14 @@ use axum::extract::{Path, State};
 use axum::http::StatusCode;
 use axum::routing::get;
 use axum::Router;
+use freighter_index::IndexClient;
 use freighter_storage::StorageClient;
 use semver::Version;
 use std::sync::Arc;
 
 pub fn downloads_router<I, S, A>() -> Router<Arc<ServiceState<I, S, A>>>
 where
-    I: Send + Sync + 'static,
+    I: IndexClient + Send + Sync + 'static,
     S: StorageClient + Send + Sync + 'static,
     A: Send + Sync + 'static,
 {
@@ -24,8 +25,11 @@ async fn serve_crate<I, S, A>(
     Path((name, version)): Path<(String, Version)>,
 ) -> axum::response::Result<Bytes>
 where
+    I: IndexClient,
     S: StorageClient,
 {
+    let _is_yanked = state.index.confirm_existence(&name, &version).await?;
+
     let crate_bytes = state
         .storage
         .pull_crate(&name, &version.to_string())

--- a/freighter/Cargo.toml
+++ b/freighter/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freighter"
-version = "0.0.9"
+version = "0.0.10"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["Noah Kennedy <nomaxx117@gmail.com>"]


### PR DESCRIPTION
This change adds metrics to the various steps of the publication process on the index, adds support for categories and keywords, adds more outputs to the json for searches and crate listing, and adds a check to verify that something is in the index before downloading, fixing an issue where a crate pushed to the crates storage could potentially be visible even if the transaction failed to commit.

The download storage is always treated as safe to overwrite, so it is assumed that crates which may not be downloadable could be in there.