### PR TITLE
Adds some basic integration tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -799,17 +799,21 @@ name = "freighter-server"
 version = "0.1.0-rc"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "axum-extra",
  "freighter-auth",
  "freighter-index",
  "freighter-storage",
+ "hyper",
  "metrics",
  "semver",
  "serde",
  "serde_json",
  "sha2",
+ "tokio",
  "tokio-stream",
+ "tower",
  "tower-http",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ bytes = "1.1.0"
 clap = { version = "4.0", default-features = false }
 deadpool-postgres = "0.10.5"
 futures-util = { version = "0.3.16", default-features = false }
+hyper = { version = "0.14", default-features = false }
 metrics = "0.21.0"
 metrics-exporter-prometheus = { version = "0.12.1", default-features = false }
 postgres-types = "0.2.1"
@@ -36,6 +37,7 @@ sha2 = "0.10.0"
 thiserror = "1.0.2"
 tokio = "1.23.1"
 tokio-stream = { version = "0.1.9", default-features = false }
+tower = { version = "0.4", default-features = false }
 tower-http = "0.4.0"
 tracing = "0.1.21"
 tracing-subscriber = { version = "0.3.0", default-features = false }

--- a/freighter-index/src/api_types.rs
+++ b/freighter-index/src/api_types.rs
@@ -2,7 +2,7 @@ use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug, Default, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[cfg_attr(
     feature = "postgresql-backend",
     derive(postgres_types::ToSql, postgres_types::FromSql)
@@ -19,7 +19,7 @@ pub enum DependencyKind {
     Build,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct CrateVersion {
     /// The name of the package.
     ///
@@ -78,7 +78,7 @@ pub struct CrateVersion {
     pub features2: HashMap<String, Vec<String>>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Clone)]
 pub struct Dependency {
     /// Name of the dependency.
     ///

--- a/freighter-server/Cargo.toml
+++ b/freighter-server/Cargo.toml
@@ -26,3 +26,9 @@ sha2 = { workspace = true }
 tokio-stream = { workspace = true }
 tower-http = { workspace = true, features = ["catch-panic", "trace"] }
 tracing = { workspace = true }
+
+[dev-dependencies]
+async-trait = { workspace = true }
+hyper = { workspace = true }
+tokio = { workspace = true }
+tower = { workspace = true }

--- a/freighter-server/src/api.rs
+++ b/freighter-server/src/api.rs
@@ -109,7 +109,7 @@ where
             }),
         )
         .await
-        .map(|x| Json(x))?;
+        .map(Json)?;
 
     Ok(resp)
 }

--- a/freighter-server/src/downloads.rs
+++ b/freighter-server/src/downloads.rs
@@ -46,7 +46,7 @@ where
         .pull_crate(&name, &version.to_string())
         .await?;
 
-    Ok(Bytes::from(crate_bytes))
+    Ok(crate_bytes)
 }
 
 async fn handle_downloads_fallback() -> StatusCode {

--- a/freighter-server/src/index.rs
+++ b/freighter-server/src/index.rs
@@ -59,7 +59,7 @@ where
 
     let crate_versions = state.index.get_sparse_entry(&crate_name).await?;
 
-    let resp = JsonLines::new(tokio_stream::iter(crate_versions).map(|c| Ok(c)));
+    let resp = JsonLines::new(tokio_stream::iter(crate_versions).map(Ok));
 
     Ok(resp)
 }

--- a/freighter-server/tests/api.rs
+++ b/freighter-server/tests/api.rs
@@ -1,0 +1,184 @@
+pub mod common;
+
+use crate::common::{utils::crate_version, MockIndexProvider, ServiceStateBuilder};
+
+use axum::http::{Request, StatusCode};
+use freighter_server::api;
+use hyper::{header::AUTHORIZATION, Body};
+use serde_json::Value;
+use std::collections::BTreeMap;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn publish_crate() {
+    let router = api::api_router();
+
+    const TOKEN: &str = "12345";
+
+    let state = ServiceStateBuilder::default()
+        .auth_provider(common::MockAuthProvider {
+            valid_tokens: [TOKEN.to_owned()].into(),
+        })
+        .build();
+
+    let json = serde_json::json!({
+        "name": "example-lib",
+        "vers": "1.0.1",
+        "deps": [],
+        "features": {},
+        "description": null,
+        "documentation": null,
+        "homepage": null,
+        "readme": null,
+        "readme_file": null,
+        "license": null,
+        "license_file": null,
+        "repository": null,
+        "badges": null,
+        "links": null,
+    })
+    .to_string();
+
+    // https://github.com/rust-lang/cargo/blob/20df9e40a4d41dd08478549915588395e55efb4c/crates/crates-io/lib.rs#L259
+    let payload = {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
+        payload.extend_from_slice(json.as_bytes());
+        let tarball: Vec<u8> = (0..100).collect();
+        payload.extend_from_slice(&(tarball.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&tarball);
+        payload
+    };
+
+    let response = router
+        .with_state(state)
+        .oneshot(
+            Request::builder()
+                .uri("/new")
+                .method("PUT")
+                .header(AUTHORIZATION, TOKEN)
+                .body(payload.into())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn publish_crate_auth_denied() {
+    let router = api::api_router();
+
+    let state = ServiceStateBuilder::default()
+        .auth_provider(common::MockAuthProvider {
+            valid_tokens: [].into(),
+        })
+        .build();
+
+    let json = serde_json::json!({
+        "name": "example-lib",
+        "vers": "1.0.1",
+        "deps": [],
+        "features": {},
+        "description": null,
+        "documentation": null,
+        "homepage": null,
+        "readme": null,
+        "readme_file": null,
+        "license": null,
+        "license_file": null,
+        "repository": null,
+        "badges": null,
+        "links": null,
+    })
+    .to_string();
+
+    // https://github.com/rust-lang/cargo/blob/20df9e40a4d41dd08478549915588395e55efb4c/crates/crates-io/lib.rs#L259
+    let payload = {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
+        payload.extend_from_slice(json.as_bytes());
+        let tarball: Vec<u8> = (0..100).collect();
+        payload.extend_from_slice(&(tarball.len() as u32).to_le_bytes());
+        payload.extend_from_slice(&tarball);
+        payload
+    };
+
+    let response = router
+        .with_state(state)
+        .oneshot(
+            Request::builder()
+                .uri("/new")
+                .method("PUT")
+                .header(AUTHORIZATION, "1234")
+                .body(payload.into())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn list_all_crates() {
+    let router = api::api_router();
+
+    let crates = BTreeMap::from([
+        (
+            "example-lib".to_owned(),
+            ["1.3.0", "1.3.1"]
+                .iter()
+                .map(|version| crate_version("example-lib", version))
+                .collect::<Vec<_>>(),
+        ),
+        (
+            "freighter".to_owned(),
+            ["0.1.0", "0.1.1"]
+                .iter()
+                .map(|version| crate_version("freighter", version))
+                .collect::<Vec<_>>(),
+        ),
+    ]);
+
+    let state = ServiceStateBuilder::default()
+        .index_provider(MockIndexProvider { crates })
+        .build();
+
+    let response = router
+        .with_state(state)
+        .oneshot(Request::builder().uri("/all").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let value: Value = serde_json::from_slice(&body).unwrap();
+    assert_eq!(
+        value,
+        serde_json::json!([
+          {
+            "name": "example-lib",
+            "max_version": "1.3.1",
+            "description": "Description example-lib 1.3.1",
+            "homepage": "e.com",
+            "repository": "ssh://git@b.com/a/f.git",
+            "documentation": null,
+            "keywords": [ "example" ],
+            "categories": [ "a", "x" ]
+          },
+          {
+            "name": "freighter",
+            "max_version": "0.1.1",
+            "description": "Description freighter 0.1.1",
+            "homepage": "e.com",
+            "repository": "ssh://git@b.com/a/f.git",
+            "documentation": null,
+            "keywords": [ "example" ],
+            "categories": [ "a", "x" ]
+          }
+        ])
+    );
+}

--- a/freighter-server/tests/common/mod.rs
+++ b/freighter-server/tests/common/mod.rs
@@ -1,0 +1,191 @@
+pub mod utils;
+
+use std::{
+    collections::{BTreeMap, HashSet},
+    future::Future,
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    pin::Pin,
+    sync::Arc,
+};
+
+use async_trait::async_trait;
+use axum::body::Bytes;
+use freighter_auth::{AuthError, AuthProvider, AuthResult, ListedOwner};
+use freighter_index::{
+    CompletedPublication, CrateVersion, IndexError, IndexProvider, IndexResult, ListQuery, Publish,
+    SearchResults, SearchResultsEntry,
+};
+use freighter_server::{ServiceConfig, ServiceState};
+use freighter_storage::{StorageProvider, StorageResult};
+use semver::Version;
+
+#[derive(Default)]
+pub struct MockIndexProvider {
+    pub crates: BTreeMap<String, Vec<CrateVersion>>,
+}
+
+#[async_trait]
+impl IndexProvider for MockIndexProvider {
+    async fn get_sparse_entry(&self, crate_name: &str) -> IndexResult<Vec<CrateVersion>> {
+        if let Some(versions) = self.crates.get(crate_name).cloned() {
+            Ok(versions)
+        } else {
+            Err(IndexError::NotFound)
+        }
+    }
+    async fn confirm_existence(&self, _crate_name: &str, _version: &Version) -> IndexResult<bool> {
+        unimplemented!()
+    }
+    async fn yank_crate(&self, _crate_name: &str, _version: &Version) -> IndexResult<()> {
+        unimplemented!()
+    }
+    async fn unyank_crate(&self, _crate_name: &str, _version: &Version) -> IndexResult<()> {
+        unimplemented!()
+    }
+    async fn search(&self, _query_string: &str, _limit: usize) -> IndexResult<SearchResults> {
+        unimplemented!()
+    }
+    async fn publish(
+        &self,
+        _version: &Publish,
+        _checksum: &str,
+        _end_step: Pin<Box<dyn Future<Output = anyhow::Result<()>> + Send>>,
+    ) -> IndexResult<CompletedPublication> {
+        Ok(CompletedPublication { warnings: None })
+    }
+
+    async fn list(&self, _pagination: &ListQuery) -> IndexResult<Vec<SearchResultsEntry>> {
+        Ok(self
+            .crates
+            .iter()
+            .map(|(k, v)| {
+                let max_version = v
+                    .iter()
+                    .max_by_key(|v| v.vers.clone())
+                    .map(|v| v.vers.clone())
+                    .unwrap();
+                SearchResultsEntry {
+                    name: k.clone(),
+                    description: format!("Description {k} {max_version}"),
+                    max_version,
+                    homepage: Some("e.com".to_owned()),
+                    repository: Some("ssh://git@b.com/a/f.git".to_owned()),
+                    documentation: None,
+                    keywords: vec!["example".to_owned()],
+                    categories: vec!["a".to_owned(), "x".to_owned()],
+                }
+            })
+            .collect())
+    }
+}
+
+#[derive(Clone, Default)]
+pub struct MockStorageProvider;
+
+#[async_trait]
+impl StorageProvider for MockStorageProvider {
+    async fn pull_crate(&self, _name: &str, _version: &str) -> StorageResult<Bytes> {
+        unimplemented!()
+    }
+    async fn put_crate(
+        &self,
+        _name: &str,
+        _version: &str,
+        _crate_bytes: &[u8],
+    ) -> StorageResult<()> {
+        unimplemented!()
+    }
+}
+
+#[derive(Default)]
+pub struct MockAuthProvider {
+    pub valid_tokens: HashSet<String>,
+}
+
+#[async_trait]
+impl AuthProvider for MockAuthProvider {
+    async fn register(&self, _username: &str, _password: &str) -> AuthResult<String> {
+        unimplemented!()
+    }
+    async fn login(&self, _username: &str, _password: &str) -> AuthResult<String> {
+        unimplemented!()
+    }
+    async fn list_owners(&self, _token: &str, _crate_name: &str) -> AuthResult<Vec<ListedOwner>> {
+        unimplemented!()
+    }
+    async fn add_owners(&self, _token: &str, _users: &[&str], _crate_name: &str) -> AuthResult<()> {
+        unimplemented!()
+    }
+    async fn remove_owners(
+        &self,
+        _token: &str,
+        _users: &[&str],
+        _crate_name: &str,
+    ) -> AuthResult<()> {
+        unimplemented!()
+    }
+    async fn publish(&self, token: &str, _crate_name: &str) -> AuthResult<()> {
+        if self.valid_tokens.contains(token) {
+            Ok(())
+        } else {
+            Err(AuthError::Unauthorized)
+        }
+    }
+    async fn auth_yank(&self, _token: &str, _crate_name: &str) -> AuthResult<()> {
+        unimplemented!()
+    }
+    async fn auth_unyank(&self, _token: &str, _crate_name: &str) -> AuthResult<()> {
+        unimplemented!()
+    }
+}
+
+pub struct ServiceStateBuilder {
+    config: ServiceConfig,
+    index: MockIndexProvider,
+    storage: MockStorageProvider,
+    auth: MockAuthProvider,
+}
+
+impl Default for ServiceStateBuilder {
+    fn default() -> Self {
+        Self {
+            config: ServiceConfig {
+                address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3000),
+                download_endpoint: "localhost:4000".to_owned(),
+                api_endpoint: "localhost:5000".to_owned(),
+                metrics_address: SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 3001),
+            },
+            index: Default::default(),
+            storage: Default::default(),
+            auth: Default::default(),
+        }
+    }
+}
+
+impl ServiceStateBuilder {
+    pub fn index_provider(mut self, provider: MockIndexProvider) -> Self {
+        self.index = provider;
+        self
+    }
+
+    pub fn storage_provider(mut self, provider: MockStorageProvider) -> Self {
+        self.storage = provider;
+        self
+    }
+
+    pub fn auth_provider(mut self, provider: MockAuthProvider) -> Self {
+        self.auth = provider;
+        self
+    }
+
+    pub fn build(
+        self,
+    ) -> Arc<ServiceState<MockIndexProvider, MockStorageProvider, MockAuthProvider>> {
+        Arc::new(ServiceState {
+            config: self.config,
+            index: self.index,
+            storage: self.storage,
+            auth: self.auth,
+        })
+    }
+}

--- a/freighter-server/tests/common/utils.rs
+++ b/freighter-server/tests/common/utils.rs
@@ -1,0 +1,16 @@
+use freighter_index::CrateVersion;
+use semver::Version;
+
+pub fn crate_version(name: &str, version: &str) -> CrateVersion {
+    CrateVersion {
+        name: name.to_owned(),
+        vers: Version::parse(version).unwrap(),
+        deps: vec![],
+        cksum: "beefcafe".to_owned(),
+        features: Default::default(),
+        yanked: false,
+        links: None,
+        v: 2,
+        features2: Default::default(),
+    }
+}

--- a/freighter-server/tests/index.rs
+++ b/freighter-server/tests/index.rs
@@ -1,0 +1,100 @@
+pub mod common;
+
+use crate::common::{utils::crate_version, MockIndexProvider, ServiceStateBuilder};
+
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use freighter_server::index;
+use std::collections::BTreeMap;
+use tower::ServiceExt;
+
+#[tokio::test]
+async fn index_config_endpoint() {
+    let router = index::index_router();
+
+    let state = ServiceStateBuilder::default().build();
+
+    let response = router
+        .with_state(state.clone())
+        .oneshot(
+            Request::builder()
+                .uri("/config.json")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let body = std::str::from_utf8(&body).unwrap();
+    assert_eq!(
+        body,
+        &format!(
+            r#"{{"dl":"{}","api":"{}"}}"#,
+            state.config.download_endpoint, state.config.api_endpoint
+        )
+    );
+}
+
+#[tokio::test]
+async fn missing_crate() {
+    let router = index::index_router();
+
+    let state = ServiceStateBuilder::default().build();
+
+    let response = router
+        .with_state(state)
+        .oneshot(
+            Request::builder()
+                .uri("/ex/am/example-lib")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn valid_crate() {
+    let router = index::index_router();
+
+    let crates = BTreeMap::from([(
+        "example-lib".to_owned(),
+        ["1.3.0", "1.3.1"]
+            .iter()
+            .map(|version| crate_version("example-lib", version))
+            .collect::<Vec<_>>(),
+    )]);
+
+    let state = ServiceStateBuilder::default()
+        .index_provider(MockIndexProvider { crates })
+        .build();
+
+    let response = router
+        .with_state(state)
+        .oneshot(
+            Request::builder()
+                .uri("/ex/am/example-lib")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = hyper::body::to_bytes(response.into_body()).await.unwrap();
+    let body = std::str::from_utf8(&body).unwrap();
+    assert_eq!(
+        body,
+        r#"{"name":"example-lib","vers":"1.3.0","deps":[],"cksum":"beefcafe","features":{},"yanked":false,"links":null,"v":2,"features2":{}}
+{"name":"example-lib","vers":"1.3.1","deps":[],"cksum":"beefcafe","features":{},"yanked":false,"links":null,"v":2,"features2":{}}
+"#
+    );
+}


### PR DESCRIPTION
Mainly to assert the status codes and shape of responses served by the API. 

* Changes a `query_row` to `query` so that we can return a 401 instead of 500 when token is invalid.

Some of the repeated code has been refactored in a follow up PR I have which adds E2E tess.