### PR TITLE
Adds e2e test

### DIFF
--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -20,6 +20,7 @@ jobs:
       - clippy
       - rustfmt
       - tests
+      - e2e
     steps:
       - run: exit 0
 
@@ -72,7 +73,7 @@ jobs:
           toolchain: stable
       - uses: taiki-e/install-action@cargo-hack
       - uses: Swatinem/rust-cache@v2
-      - run: cargo hack test --each-feature
+      - run: cargo hack test --each-feature --exclude-features test_e2e
 
   minimal-versions:
     runs-on: ubuntu-latest
@@ -93,3 +94,59 @@ jobs:
           # Update Cargo.lock to minimal version dependencies.
           cargo update -Z direct-minimal-versions
           cargo hack check --all-features --ignore-private
+
+  e2e:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:14
+        env:
+          POSTGRES_USER: freighter
+          POSTGRES_PASSWORD: crates-crates-crates
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+      s3:
+        image: adobe/s3mock
+        env:
+          initialBuckets: crates
+          validKmsKeys: "arn:aws:kms:us-east-1:1234567890:key/valid-secret"
+        ports:
+          - 9090:9090
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install psql
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes --no-install-recommends postgresql-client
+      - name: Run DB migrations
+        run: |
+          psql -h localhost -f sql/init-index-db.sql
+          psql -h localhost -f sql/init-auth-db.sql
+        env:
+          PGUSER: freighter
+          PGPASSWORD: crates-crates-crates
+      - name: Run E2E tests
+        run: cargo test --features=test_e2e -- e2e
+        env:
+          SERVER_ADDR: "127.0.0.1:3000"
+          POSTGRES_HOST: localhost
+          POSTGRES_PORT: 5432
+          POSTGRES_USER: freighter
+          POSTGRES_PASSWORD: crates-crates-crates
+          POSTGRES_DBNAME: freighter
+          BUCKET_NAME: crates
+          BUCKET_ENDPOINT: "http://127.0.0.1:9090"
+          BUCKET_ACCESS_KEY_ID: "1234567890"
+          BUCKET_ACCESS_KEY_SECRET: valid-secret

--- a/.github/workflows/on-push.yaml
+++ b/.github/workflows/on-push.yaml
@@ -96,11 +96,14 @@ jobs:
           cargo hack check --all-features --ignore-private
 
   e2e:
+    strategy:
+      matrix:
+        postgres_version: [ 14, 15, 16beta2 ]
     runs-on: ubuntu-latest
 
     services:
       postgres:
-        image: postgres:14
+        image: postgres:${{ matrix.postgres_version }}
         env:
           POSTGRES_USER: freighter
           POSTGRES_PASSWORD: crates-crates-crates

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,6 +670,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -802,11 +811,13 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
+ "deadpool-postgres",
  "freighter-auth",
  "freighter-index",
  "freighter-storage",
  "hyper",
  "metrics",
+ "reqwest",
  "semver",
  "serde",
  "serde_json",
@@ -1647,6 +1658,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
+name = "reqwest"
+version = "0.11.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
+dependencies = [
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
 name = "retain_mut"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2320,6 +2365,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2502,6 +2559,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "xmlparser"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ metrics = "0.21.0"
 metrics-exporter-prometheus = { version = "0.12.1", default-features = false }
 postgres-types = "0.2.1"
 rand = "0.8.4"
+reqwest = { version = "0.11", default-features = false }
 semver = "1.0.0"
 serde = "1.0.139"
 serde_json = "1.0.71"

--- a/README.md
+++ b/README.md
@@ -34,5 +34,54 @@ international human rights law, but also because no one has gotten around to thi
 
 If you want to contribute a user interface for Freighter, PRs are welcome!
 
+## Running locally
+
+To try out Freighter **locally**, start a `postgres:14` server:
+```
+docker run -it -e POSTGRES_USER=freighter -e POSTGRES_PASSWORD=crates-crates-crates -p 5432:5432 -v /data:/var/lib/postgresql/data postgres:14
+```
+
+Run the migrations, e.g. with a locally installed `psql`:
+```
+PGPASSWORD=crates-crates-crates psql -U freighter -h localhost -f sql/init-index-db.sql
+PGPASSWORD=crates-crates-crates psql -U freighter -h localhost -f sql/init-auth-db.sql
+```
+
+Next, we need an S3-compatible server. You can use an S3 emulator for testing purposes:
+```
+docker run -it -p 9090:9090 -e initialBuckets=crates -e validKmsKeys="arn:aws:kms:us-east-1:1234567890:key/valid-secret" -e debug=true -t adobe/s3mock
+```
+
+Finally, a config file using the above:
+```yaml
+service:
+  address: "127.0.0.1:3000"
+  download_endpoint: "127.0.0.1:3000/downloads/{crate}/{version}"
+  api_endpoint: "127.0.0.1:3000"
+  metrics_address: "127.0.0.1:3001"
+
+index_db: &db
+  dbname: "freighter"
+  user: "freighter"
+  password: "crates-crates-crates"
+  host: "localhost"
+  port: 5432
+
+auth_db: *db
+
+store:
+  name: "crates"
+  endpoint_url: "http://127.0.0.1:9090"
+  region: "us-east-1"
+  access_key_id: "1234567890"
+  access_key_secret: "valid-secret"
+```
+
+Start Freighter:
+```
+cargo run -p freighter -- -c config.yaml
+```
+
+
 [tracing]: https://docs.rs/tracing/latest/tracing/
 [metrics]: https://docs.rs/metrics/latest/metrics/

--- a/freighter-index/sql/publish/get-or-insert-crate.sql
+++ b/freighter-index/sql/publish/get-or-insert-crate.sql
@@ -5,4 +5,3 @@ union all
 select *
 from crates
 where name = $1
-  and registry is null

--- a/freighter-index/src/postgres_client.rs
+++ b/freighter-index/src/postgres_client.rs
@@ -421,7 +421,7 @@ impl IndexProvider for PgIndexProvider {
                 ],
             )
             .await
-            .context("Failed to insert version")?;
+            .map_err(|_| IndexError::Conflict("Failed to insert version".to_owned()))?;
 
         histogram!(
             "publish_component_duration_seconds", insert_version_timer.elapsed(),
@@ -529,7 +529,7 @@ impl IndexProvider for PgIndexProvider {
             rows.chunks(*per_page)
                 .nth(page.unwrap_or_default())
                 .unwrap_or(&[])
-                .into_iter()
+                .iter()
                 .map(search_row_to_entry)
                 .collect()
         } else {
@@ -546,7 +546,7 @@ fn search_row_to_entry(row: &Row) -> SearchResultsEntry {
     // we should never receive 0 versions from our query
     let max_version = versions
         .iter()
-        .map(|s| Version::parse(&s).unwrap())
+        .map(|s| Version::parse(s).unwrap())
         .max()
         .unwrap();
 

--- a/freighter-server/Cargo.toml
+++ b/freighter-server/Cargo.toml
@@ -10,6 +10,9 @@ description = "Crate index traits and implementations for the freighter registry
 categories = ["asynchronous"]
 keywords = ["registries", "freighter"]
 
+[features]
+test_e2e = []
+
 [dependencies]
 freighter-auth = { workspace = true, features = ["yes-backend"] }
 freighter-index = { workspace = true, features = ["postgresql-backend"] }
@@ -29,6 +32,8 @@ tracing = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }
+deadpool-postgres = { workspace = true }
 hyper = { workspace = true }
+reqwest = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/freighter-server/Cargo.toml
+++ b/freighter-server/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["asynchronous"]
 keywords = ["registries", "freighter"]
 
 [features]
-test_e2e = []
+test_e2e = ["deadpool-postgres", "reqwest"]
 
 [dependencies]
 freighter-auth = { workspace = true, features = ["yes-backend"] }
@@ -21,19 +21,19 @@ freighter-storage = { workspace = true, features = ["s3-backend"] }
 anyhow = { workspace = true }
 axum = { workspace = true, features = ["json", "query", "form", "matched-path"] }
 axum-extra = { workspace = true, features = ["json-lines"] }
+deadpool-postgres = { workspace = true, optional = true }
 metrics = { workspace = true }
 semver = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+reqwest = { workspace = true, optional = true }
 tokio-stream = { workspace = true }
 tower-http = { workspace = true, features = ["catch-panic", "trace"] }
 tracing = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }
-deadpool-postgres = { workspace = true }
 hyper = { workspace = true }
-reqwest = { workspace = true }
 tokio = { workspace = true }
 tower = { workspace = true }

--- a/freighter-server/tests/api.rs
+++ b/freighter-server/tests/api.rs
@@ -1,6 +1,9 @@
 pub mod common;
 
-use crate::common::{utils::crate_version, MockIndexProvider, ServiceStateBuilder};
+use crate::common::{
+    utils::{crate_version, generate_crate_payload},
+    MockIndexProvider, ServiceStateBuilder,
+};
 
 use axum::http::{Request, StatusCode};
 use freighter_server::api;
@@ -21,34 +24,7 @@ async fn publish_crate() {
         })
         .build();
 
-    let json = serde_json::json!({
-        "name": "example-lib",
-        "vers": "1.0.1",
-        "deps": [],
-        "features": {},
-        "description": null,
-        "documentation": null,
-        "homepage": null,
-        "readme": null,
-        "readme_file": null,
-        "license": null,
-        "license_file": null,
-        "repository": null,
-        "badges": null,
-        "links": null,
-    })
-    .to_string();
-
-    // https://github.com/rust-lang/cargo/blob/20df9e40a4d41dd08478549915588395e55efb4c/crates/crates-io/lib.rs#L259
-    let payload = {
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
-        payload.extend_from_slice(json.as_bytes());
-        let tarball: Vec<u8> = (0..100).collect();
-        payload.extend_from_slice(&(tarball.len() as u32).to_le_bytes());
-        payload.extend_from_slice(&tarball);
-        payload
-    };
+    let payload = generate_crate_payload("example-lib", "1.0.1", &[1u8; 100]);
 
     let response = router
         .with_state(state)
@@ -76,34 +52,7 @@ async fn publish_crate_auth_denied() {
         })
         .build();
 
-    let json = serde_json::json!({
-        "name": "example-lib",
-        "vers": "1.0.1",
-        "deps": [],
-        "features": {},
-        "description": null,
-        "documentation": null,
-        "homepage": null,
-        "readme": null,
-        "readme_file": null,
-        "license": null,
-        "license_file": null,
-        "repository": null,
-        "badges": null,
-        "links": null,
-    })
-    .to_string();
-
-    // https://github.com/rust-lang/cargo/blob/20df9e40a4d41dd08478549915588395e55efb4c/crates/crates-io/lib.rs#L259
-    let payload = {
-        let mut payload = Vec::new();
-        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
-        payload.extend_from_slice(json.as_bytes());
-        let tarball: Vec<u8> = (0..100).collect();
-        payload.extend_from_slice(&(tarball.len() as u32).to_le_bytes());
-        payload.extend_from_slice(&tarball);
-        payload
-    };
+    let payload = generate_crate_payload("example-lib", "1.0.1", &[1u8; 100]);
 
     let response = router
         .with_state(state)

--- a/freighter-server/tests/common/utils.rs
+++ b/freighter-server/tests/common/utils.rs
@@ -14,3 +14,35 @@ pub fn crate_version(name: &str, version: &str) -> CrateVersion {
         features2: Default::default(),
     }
 }
+
+pub fn generate_crate_payload(name: &str, vers: &str, tarball: &[u8]) -> Vec<u8> {
+    let json = serde_json::json!({
+        "name": name,
+        "vers": vers,
+        "deps": [],
+        "features": {},
+        "description": null,
+        "documentation": null,
+        "homepage": null,
+        "readme": null,
+        "readme_file": null,
+        "license": null,
+        "license_file": null,
+        "repository": null,
+        "badges": null,
+        "links": null,
+    })
+    .to_string();
+
+    // https://github.com/rust-lang/cargo/blob/20df9e40a4d41dd08478549915588395e55efb4c/crates/crates-io/lib.rs#L259
+    let payload = {
+        let mut payload = Vec::new();
+        payload.extend_from_slice(&(json.len() as u32).to_le_bytes());
+        payload.extend_from_slice(json.as_bytes());
+        payload.extend_from_slice(&(tarball.len() as u32).to_le_bytes());
+        payload.extend_from_slice(tarball);
+        payload
+    };
+
+    payload
+}

--- a/freighter-server/tests/e2e.rs
+++ b/freighter-server/tests/e2e.rs
@@ -1,0 +1,159 @@
+#![cfg(feature = "test_e2e")]
+pub mod common;
+
+use std::env::var;
+
+use anyhow::{Context, Result};
+use axum::{routing::IntoMakeService, Router, Server};
+use deadpool_postgres::Config;
+use freighter_auth::pg_backend::PgAuthProvider;
+use freighter_index::postgres_client::PgIndexProvider;
+use freighter_server::ServiceConfig;
+use freighter_storage::s3_client::S3StorageProvider;
+use hyper::{header::AUTHORIZATION, server::conn::AddrIncoming, Body, StatusCode};
+
+use crate::common::utils::generate_crate_payload;
+
+#[derive(Clone)]
+struct TestServerConfig {
+    db: Config,
+    server_addr: String,
+    bucket_name: String,
+    bucket_endpoint_url: String,
+    bucket_access_key_id: String,
+    bucket_access_key_secret: String,
+}
+
+impl TestServerConfig {
+    fn from_env() -> TestServerConfig {
+        Self {
+            db: Config {
+                user: Some(var("POSTGRES_USER").unwrap_or("freighter".to_owned())),
+                password: Some(
+                    var("POSTGRES_PASSWORD").unwrap_or("crates-crates-crates".to_owned()),
+                ),
+                dbname: Some(var("POSTGRES_DBNAME").unwrap_or("freighter".to_owned())),
+                host: Some(var("POSTGRES_HOST").unwrap_or("localhost".to_owned())),
+                port: Some(
+                    var("POSTGRES_PORT")
+                        .map(|p| p.parse::<u16>().unwrap())
+                        .unwrap_or(5432),
+                ),
+                ..Default::default()
+            },
+            server_addr: var("SERVER_ADDR").unwrap_or("127.0.0.1:3000".to_owned()),
+            bucket_name: var("BUCKET_NAME").unwrap_or("crates".to_owned()),
+            bucket_endpoint_url: var("BUCKET_ENDPOINT")
+                .unwrap_or("http://127.0.0.1:9090".to_owned()),
+            bucket_access_key_id: var("BUCKET_ACCESS_KEY_ID").unwrap_or("1234567890".to_owned()),
+            bucket_access_key_secret: var("BUCKET_ACCESS_KEY_SECRET")
+                .unwrap_or("valid-secret".to_owned()),
+        }
+    }
+}
+
+fn server(
+    config: &TestServerConfig,
+) -> Result<Server<AddrIncoming, IntoMakeService<Router<(), Body>>>> {
+    let index_client =
+        PgIndexProvider::new(config.db.clone()).context("Failed to construct index client")?;
+    let storage_client = S3StorageProvider::new(
+        &config.bucket_name,
+        &config.bucket_endpoint_url,
+        "us-east-1",
+        &config.bucket_access_key_id,
+        &config.bucket_access_key_secret,
+    );
+    let auth_client =
+        PgAuthProvider::new(config.db.clone()).context("Failed to initialize auth client")?;
+
+    let service = ServiceConfig {
+        address: config.server_addr.parse()?,
+        download_endpoint: format!("{}/downloads/{{crate}}/{{version}}", config.server_addr),
+        api_endpoint: config.server_addr.to_owned(),
+        metrics_address: "127.0.0.1:9999".parse()?,
+    };
+
+    let router = freighter_server::router(service, index_client, storage_client, auth_client);
+
+    Ok(axum::Server::bind(&config.server_addr.parse()?).serve(router.into_make_service()))
+}
+
+#[tokio::test]
+async fn e2e_publish_crate() {
+    let config = TestServerConfig::from_env();
+    let server_addr = config.server_addr.clone();
+
+    const CRATE_TO_PUBLISH: &str = "freighter-vegetables";
+
+    // 0. Start Freighter
+    {
+        let server = server(&config).unwrap();
+        tokio::spawn(server);
+    }
+
+    // 1. Create a user to get a publish token.
+    let client = reqwest::Client::new();
+
+    let token = client
+        .post(format!("http://{server_addr}/api/v1/crates/account"))
+        .form(&[("username", "kargo"), ("password", "krab")])
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+
+    // 2. Publish a crate!
+    let tarball = [1u8; 100];
+    let publish_res = client
+        .put(format!("http://{server_addr}/api/v1/crates/new"))
+        .header(AUTHORIZATION, token.clone())
+        .body(generate_crate_payload(CRATE_TO_PUBLISH, "1.2.3", &tarball))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(publish_res.status(), StatusCode::OK);
+
+    // 3. Try and publish it again, expect 409 Conflict.
+    let publish_res = client
+        .put(format!("http://{server_addr}/api/v1/crates/new"))
+        .header(AUTHORIZATION, token.clone())
+        .body(generate_crate_payload(CRATE_TO_PUBLISH, "1.2.3", &tarball))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(publish_res.status(), StatusCode::CONFLICT);
+
+    // 4. Publish a newer version
+    let publish_res = client
+        .put(format!("http://{server_addr}/api/v1/crates/new"))
+        .header(AUTHORIZATION, token.clone())
+        .body(generate_crate_payload(
+            CRATE_TO_PUBLISH,
+            "2.0.0",
+            &[2u8; 100],
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(publish_res.status(), StatusCode::OK);
+
+    // 5. Fetch our crate
+    let crate_res = client
+        .get(format!(
+            "http://{server_addr}/downloads/{CRATE_TO_PUBLISH}/1.2.3"
+        ))
+        .send()
+        .await
+        .unwrap();
+
+    assert_eq!(crate_res.status(), StatusCode::OK);
+
+    let body = crate_res.bytes().await.unwrap();
+    assert_eq!(body, &tarball[..])
+}

--- a/sql/init-index-db.sql
+++ b/sql/init-index-db.sql
@@ -3,12 +3,12 @@ create table crates
 (
     id            integer primary key generated always as identity,
     name          text not null,
-    registry      text,
+    registry      text not null default '',
     description   text,
     documentation text,
     homepage      text,
     repository    text,
-    unique nulls not distinct (name, registry)
+    unique (name, registry)
 );
 
 drop table if exists keywords cascade;


### PR DESCRIPTION
* Documents a non-prod local setup.
* Removes `unique nulls not distinct` as it is not compatible with pg14.
  * I have made it default to empty string at the db level, which I
    think gives equivalent behaviour but didn't think about it too hard.
    The behaviour should be covered by the e2e test.
* Fixes a 500 to return 409 Conflict.
* Some clippy hint changes.