### PR TITLE
bin: graceful shutdown on sigterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1882,6 +1882,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2069,6 +2078,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.4.9",
  "tokio-macros",
  "windows-sys 0.48.0",

--- a/freighter/Cargo.toml
+++ b/freighter/Cargo.toml
@@ -24,6 +24,6 @@ deadpool-postgres = { workspace = true, features = ["serde"] }
 metrics-exporter-prometheus = { workspace = true, features = ["http-listener"] }
 serde = { workspace = true, features = ["derive"] }
 serde_yaml = { workspace = true }
-tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
+tokio = { workspace = true, features = ["rt-multi-thread", "macros", "signal"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["std", "smallvec", "fmt", "tracing-log", "ansi"] }


### PR DESCRIPTION
This change adds a signal hook for sigterm, and uses that to trigger an axum graceful shutdown.

The shutdown process will finish handling any requests currently in the pipeline, as per axum's implementation of graceful shutdowns.